### PR TITLE
Remove provider arg from tool schemas

### DIFF
--- a/docs/environment_abstraction_plan.md
+++ b/docs/environment_abstraction_plan.md
@@ -13,7 +13,7 @@ This plan outlines phased steps to introduce the Environment abstraction propose
 - [x] Create an `Environment` class inside `agent.py` to keep the initial change small.
 - [x] Implement minimal interfaces:
   - `instructions()` returns the existing system prompt.
-  - `tool_schemas(provider)` returns current tool schema list.
+  - `tool_schemas()` returns current tool schema list (OpenAI schema).
   - `step(chunk)` acts as a pass-through and returns `None`.
 - [x] Instantiate `Environment` in the Agent and call `env.instructions()` and `env.tool_schemas()` when invoking the provider.
 - [x] Ensure existing behavior is preserved and tests still pass.
@@ -21,7 +21,7 @@ This plan outlines phased steps to introduce the Environment abstraction propose
 ## Phase 2: Move Prompt and Tool Ownership *(completed)*
 - [x] Move system prompt assembly logic from `agent.py` into `Environment.instructions()`.
 - [x] Relocate `ToolRegistry` creation and registration into `Environment`.
-- [x] Update `env.tool_schemas(provider)` to build provider-shaped schemas using the registry.
+- [x] Update `env.tool_schemas()` to build schemas using the registry.
 - [x] Remove equivalent code from `agent.py`.
 
 ## Phase 3: Handle Provider Events *(completed)*

--- a/src/agent_chat/agent.py
+++ b/src/agent_chat/agent.py
@@ -62,9 +62,12 @@ class Environment:
         """Return the assembled system prompt."""
         return self._instructions
 
-    def tool_schemas(self, provider: str) -> list:
-        """Return provider-shaped tool schemas."""
-        # Provider is unused in this phase but kept for compatibility
+    def tool_schemas(self) -> list:
+        """Return tool schemas.
+
+        We only support the OpenAI tool schema now, so the provider
+        parameter has been dropped from this interface.
+        """
         return self.tool_registry.get_schemas()
 
     async def _apply_hook(self, hook_name: str, value):
@@ -276,7 +279,7 @@ class Agent:
             "model": self.model_name,
             "input": self.conversation_context,  # Use local context (cookbook pattern)
             "instructions": self.env.instructions(),
-            "tools": self.env.tool_schemas("openai"),
+            "tools": self.env.tool_schemas(),
             "tool_choice": "auto",
             "store": False,  # Zero data retention
             "stream": True,


### PR DESCRIPTION
## Summary
- Simplify Environment.tool_schemas by dropping provider argument and documenting OpenAI-only support
- Adjust Agent to call updated method without provider
- Update environment abstraction docs to reflect new tool_schemas interface

## Testing
- `ruff check src/agent_chat/agent.py`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68b24991b37c8323bfd603cb0c8c6ed5