### PR TITLE
Use agent-specific logger for streaming errors

### DIFF
--- a/src/agent_chat/agent.py
+++ b/src/agent_chat/agent.py
@@ -289,8 +289,8 @@ class Agent:
         try:
             stream = await self.client.responses.create(**create_args)
         except Exception as e:
-            logger.error(f"Error creating response: {e}")
-            logger.error(f"{self.conversation_context=}")
+            self.logger.error(f"Error creating response: {e}")
+            self.logger.error(f"{self.conversation_context=}")
             return [], False
 
         tool_results = []


### PR DESCRIPTION
## Summary
- route streaming error logs through the agent-specific logger to include agent identifiers

## Testing
- `ruff check src/agent_chat/agent.py`
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68b2495008ac8323b8db9d0977c88a78