### PR TITLE
Add chat bubble favicon

### DIFF
--- a/src/agent_chat/app.py
+++ b/src/agent_chat/app.py
@@ -360,6 +360,12 @@ async def get():
     return FileResponse(str(TEMPLATES_DIR / "index.html"))
 
 
+@app.get("/favicon.svg")
+async def favicon():
+    """Serve the site favicon."""
+    return FileResponse(str(TEMPLATES_DIR / "favicon.svg"))
+
+
 @app.websocket("/ws")
 async def websocket_endpoint(websocket: WebSocket):
     await websocket.accept()

--- a/src/agent_chat/templates/favicon.svg
+++ b/src/agent_chat/templates/favicon.svg
@@ -1,0 +1,4 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 64 64">
+  <path fill="#2563eb" d="M8 8h48v24H28l-8 8v-8H8z"/>
+  <path fill="#ffffff" d="M36 14l-8 16h8l-6 18 14-22h-8z"/>
+</svg>

--- a/src/agent_chat/templates/index.html
+++ b/src/agent_chat/templates/index.html
@@ -3,6 +3,7 @@
 <head>
     <meta charset="UTF-8">
     <title>Chat App</title>
+    <link rel="icon" href="/favicon.svg" type="image/svg+xml">
     <!-- Tailwind CSS CDN -->
     <script src="https://cdn.tailwindcss.com"></script>
 


### PR DESCRIPTION
## Summary
- add minimalist chat-bubble favicon with lightning bolt
- serve the favicon via `/favicon.svg`
- reference favicon in HTML template

## Testing
- `ruff check .` (fails: line-length issues in existing code)
- `python -m py_compile src/agent_chat/app.py src/agent_chat/templates/index.html`


------
https://chatgpt.com/codex/tasks/task_e_68b24b4b00348323adb7076706975339